### PR TITLE
client: list quicktime as supported in UI

### DIFF
--- a/client/js/views/post_upload_view.js
+++ b/client/js/views/post_upload_view.js
@@ -165,7 +165,7 @@ class PostUploadView extends events.EventTarget {
             this._contentInputNode,
             {
                 extraText:
-                    "Allowed extensions: .jpg, .png, .gif, .webm, .mp4, .swf, .avif, .heif, .heic",
+                    "Allowed extensions: .jpg, .png, .gif, .webm, .mp4, .mov, .swf, .avif, .heif, .heic",
                 allowUrls: true,
                 allowMultiple: true,
                 lock: false,


### PR DESCRIPTION
Really minor point, but `.mov` isn't listed as an "allowed extension" in the UI despite it recently seeing support.

I haven't read too much into szuru's architecture, but if possible I feel it would be better to extrapolate this text from a canonical source (it looks like supported MIME types are listed above?) rather than having to manually update it.

Thanks!